### PR TITLE
Fix git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Includes two examples, one using HTTP requests and one using the more efficient 
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/YZYLAB/solana-trading-bot.git
+git clone https://github.com/YZYLAB/solana-trade-bot.git
 cd solana-trading-bot
 ```
 


### PR DESCRIPTION
The URL in the git clone command is invalid